### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ The Enkrypt AI MCP Server allows you to integrate red-teaming, prompt auditing, 
 
 With this server, you can analyze prompts, detect jailbreak attempts, simulate adversarial attacks, and bring AI safety tooling directly into your assistant-driven workflows.
 
+<a href="https://glama.ai/mcp/servers/@enkryptai/enkryptai-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@enkryptai/enkryptai-mcp-server/badge" alt="Enkrypt AI Server MCP server" />
+</a>
+
 ---
 
 ## 🚀 Features


### PR DESCRIPTION
This PR adds a badge for the [Enkrypt AI MCP Server](https://glama.ai/mcp/servers/@enkryptai/enkryptai-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@enkryptai/enkryptai-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@enkryptai/enkryptai-mcp-server/badge" alt="Enkrypt AI Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.